### PR TITLE
Prepare for final beta release

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,7 @@
 assembly-versioning-scheme: Major
-next-version: 1.1.0
-commit-message-incrementing: Disabled
+next-version: 2.0
 branches:
   develop:
-    tag: alpha
+    tag: beta
+  release:
+    tag: rc

--- a/src/dotnetTemplates.sln
+++ b/src/dotnetTemplates.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 15.0.26730.16
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ParticularTemplates", "ParticularTemplates\ParticularTemplates.csproj", "{39D942F2-4FF2-4505-86F3-832055C508BB}"
 EndProject
@@ -12,6 +12,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBusWindowsService", "Templates\NServiceBusWindowsService\NServiceBusWindowsService.csproj", "{E5AE8FAA-E717-40EA-9D0F-259FC099D7D4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScAdapterService", "Templates\ScAdapterService\ScAdapterService.csproj", "{4A32CC07-66DB-4024-914D-BF146679A03D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B2AF749A-F62F-4E32-BB5E-B3128850DCE8}"
+	ProjectSection(SolutionItems) = preProject
+		..\GitVersion.yml = ..\GitVersion.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This prepares for the final beta release. Given that 1.0 of the package targets NSB 6, I've bumped the version number to 2.0 for the NSB 7 version.