### PR TITLE
Add ctrl-c support for MacOS

### DIFF
--- a/src/Templates/NServiceBusDockerEndpoint/Program.cs
+++ b/src/Templates/NServiceBusDockerEndpoint/Program.cs
@@ -24,6 +24,7 @@ namespace NServiceBusDockerEndpoint
             else
             {
                 AppDomain.CurrentDomain.ProcessExit += ProcessExit;
+                Console.CancelKeyPress += Cancelling;
             }
 
             var host = new Host();
@@ -37,6 +38,12 @@ namespace NServiceBusDockerEndpoint
             await semaphore.WaitAsync();
 
             await host.Stop();
+        }
+
+        static void Cancelling(object sender, ConsoleCancelEventArgs e)
+        {
+            e.Cancel = true;
+            semaphore.Release();
         }
 
         static void ProcessExit(object sender, EventArgs e)

--- a/src/Tests/TemplateTests.DockerService.approved.txt
+++ b/src/Tests/TemplateTests.DockerService.approved.txt
@@ -167,6 +167,7 @@ namespace DockerService
             else
             {
                 AppDomain.CurrentDomain.ProcessExit += ProcessExit;
+                Console.CancelKeyPress += Cancelling;
             }
 
             var host = new Host();
@@ -180,6 +181,12 @@ namespace DockerService
             await semaphore.WaitAsync();
 
             await host.Stop();
+        }
+
+        static void Cancelling(object sender, ConsoleCancelEventArgs e)
+        {
+            e.Cancel = true;
+            semaphore.Release();
         }
 
         static void ProcessExit(object sender, EventArgs e)


### PR DESCRIPTION
@bording I confirmed that the Ctrl-C functionality was behaving differently when running (F5) on Visual Studio for Mac. Just adding in the `CancelKeyPress` would still drop out of the application before shutting down the endpoint (or running any code after the semaphore was released). The `ConsoleCancelEventArgs.Cancel = true` was the trick to getting execution to continue and still shutdown the console app.