### PR TITLE
Set Cancel to true so process can exit properly

### DIFF
--- a/src/Templates/NServiceBusWindowsService/Program.cs
+++ b/src/Templates/NServiceBusWindowsService/Program.cs
@@ -28,7 +28,7 @@ namespace NServiceBusWindowsService
             Console.Title = host.EndpointName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Templates/ScAdapterService/Program.cs
+++ b/src/Templates/ScAdapterService/Program.cs
@@ -28,7 +28,7 @@ namespace ScAdapterService
             Console.Title = host.AdapterName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsService.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsService.approved.txt
@@ -157,7 +157,7 @@ namespace NServiceBusWindowsService
             Console.Title = host.EndpointName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDiffFramework.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDiffFramework.approved.txt
@@ -157,7 +157,7 @@ namespace NServiceBusWindowsServiceDiffFramework
             Console.Title = host.EndpointName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDotNetCore.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDotNetCore.approved.txt
@@ -154,7 +154,7 @@ namespace NServiceBusWindowsServiceDotNetCore
             Console.Title = host.EndpointName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterService.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterService.approved.txt
@@ -110,7 +110,7 @@ namespace ScAdapterService
             Console.Title = host.AdapterName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDiffFramework.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDiffFramework.approved.txt
@@ -110,7 +110,7 @@ namespace ScAdapterServiceDiffFramework
             Console.Title = host.AdapterName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDotNetCore.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDotNetCore.approved.txt
@@ -110,7 +110,7 @@ namespace ScAdapterServiceDotNetCore
             Console.Title = host.AdapterName;
 
             var tcs = new TaskCompletionSource<object>();
-            Console.CancelKeyPress += (sender, e) => { tcs.SetResult(null); };
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; tcs.SetResult(null); };
 
             await host.Start();
             await Console.Out.WriteLineAsync("Press Ctrl+C to exit...");


### PR DESCRIPTION
This change ensures that when a project using the template is run directly as a console app, it will properly shut down.

Before this change, when running via F5 in Visual Studio, the process would never exit.

Note: this would not have had any impact when running as a service since that uses a different code path.