### PR TITLE
Updates

### DIFF
--- a/src/ParticularTemplates/ParticularTemplates.csproj
+++ b/src/ParticularTemplates/ParticularTemplates.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\Templates\**\*.*" Exclude="**\bin\**\*.*;**\obj\**\*.*" Pack="true" PackagePath="content" />
+    <None Include="..\Templates\**\*.*" Exclude="**\bin\**\*.*;**\obj\**\*.*;..\Templates\Directory.Build.props" Pack="true" PackagePath="content" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Directory.Build.props
+++ b/src/Templates/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" Condition="Exists($([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..)))" />
+
+  <PropertyGroup>
+    <LangVersion>7.0</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/Templates/NServiceBusDockerContainer/NServiceBusDockerContainer.csproj
+++ b/src/Templates/NServiceBusDockerContainer/NServiceBusDockerContainer.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Templates/NServiceBusWindowsService/NServiceBusWindowsService.csproj
+++ b/src/Templates/NServiceBusWindowsService/NServiceBusWindowsService.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Templates/ScAdapterService/ScAdapterService.csproj
+++ b/src/Templates/ScAdapterService/ScAdapterService.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Raw" Version="3.1.0" />
+    <PackageReference Include="NServiceBus.Raw" Version="3.1.1" />
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusDockerContainer.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusDockerContainer.approved.txt
@@ -26,9 +26,9 @@ NServiceBusDockerContainer.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsService.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsService.approved.txt
@@ -7,9 +7,9 @@ NServiceBusWindowsService.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDiffFramework.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDiffFramework.approved.txt
@@ -7,9 +7,9 @@ NServiceBusWindowsServiceDiffFramework.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDotNetCore.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.NServiceBusWindowsServiceDotNetCore.approved.txt
@@ -7,9 +7,9 @@ NServiceBusWindowsServiceDotNetCore.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterService.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterService.approved.txt
@@ -115,9 +115,9 @@ ScAdapterService.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Raw" Version="3.1.0" />
+    <PackageReference Include="NServiceBus.Raw" Version="3.1.1" />
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDiffFramework.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDiffFramework.approved.txt
@@ -115,9 +115,9 @@ ScAdapterServiceDiffFramework.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Raw" Version="3.1.0" />
+    <PackageReference Include="NServiceBus.Raw" Version="3.1.1" />
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDotNetCore.approved.txt
+++ b/src/Tests/ApprovalFiles/TemplateTests.ScAdapterServiceDotNetCore.approved.txt
@@ -115,9 +115,9 @@ ScAdapterServiceDotNetCore.csproj =>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.3" />
     <PackageReference Include="NServiceBus" Version="7.2.3" />
-    <PackageReference Include="NServiceBus.Raw" Version="3.1.0" />
+    <PackageReference Include="NServiceBus.Raw" Version="3.1.1" />
     <PackageReference Include="ServiceControl.TransportAdapter" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/dotnetTemplates.sln
+++ b/src/dotnetTemplates.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 15.0.26730.16
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ParticularTemplates", "ParticularTemplates\ParticularTemplates.csproj", "{39D942F2-4FF2-4505-86F3-832055C508BB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{1E6DD700-E344-49F1-9E50-7E3C37BBAB2A}"
+	ProjectSection(SolutionItems) = preProject
+		Templates\Directory.Build.props = Templates\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{80846796-EB4D-48BD-B8B1-0C76406AAE0A}"
 EndProject


### PR DESCRIPTION
Restores the LangVersion 7 enforcement for the templates as discussed in https://github.com/Particular/dotnetTemplates/pull/43#issuecomment-594217415

Also addresses all pending Dependabot PRs