### PR TITLE
Use Key Vault certificate for signing - release-4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,19 @@ jobs:
           dotnet-version: 5.0.x
       - name: Build
         run: dotnet build src --configuration Release
-      - name: Get signing cert
-        run: |
-          [IO.File]::WriteAllBytes("signing-cert.pfx", [Convert]::FromBase64String("${{ secrets.NUGET_SIGNING_CERT_BASE64 }}"))
-        shell: pwsh
-      - name: Setup NuGet for signing
-        uses: nuget/setup-nuget@v1.0.5
+      - name: Install NuGetKeyVaultSignTool
+        run: dotnet tool install --global NuGetKeyVaultSignTool
       - name: Sign NuGet Packages
-        run: nuget sign nugets\*.nupkg -CertificatePath signing-cert.pfx -Timestamper "http://timestamp.digicert.com/?alg=sha256" -NonInteractive
-        shell: pwsh
+        run: |
+          NuGetKeyVaultSignTool sign nugets\*.nupkg `
+          --file-digest sha256 `
+          --timestamp-rfc3161 http://timestamp.digicert.com `
+          --timestamp-digest sha256 `
+          --azure-key-vault-url https://particularcodesigning.vault.azure.net `
+          --azure-key-vault-client-id ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }} `
+          --azure-key-vault-tenant-id ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }} `
+          --azure-key-vault-client-secret ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }} `
+          --azure-key-vault-certificate ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Publish artifacts
         uses: actions/upload-artifact@v2.2.2
         with:


### PR DESCRIPTION
This PR converts the NuGet package signing to use a certificate stored in Key Vault, which enables us to use an EV code signing certificate.