### PR TITLE
remove sync-over-async in tests

### DIFF
--- a/src/Tests/TemplateTests.cs
+++ b/src/Tests/TemplateTests.cs
@@ -11,10 +11,11 @@ using Particular.Approvals;
 [TestFixture]
 public class TemplateTests : IDisposable
 {
-    public TemplateTests()
+    [SetUp]
+    public async Task Setup()
     {
-        Uninstall(CreateTimeoutToken()).GetAwaiter().GetResult();
-        Install(CreateTimeoutToken()).GetAwaiter().GetResult();
+        await Uninstall(CreateTimeoutToken()).ConfigureAwait(false);
+        await Install(CreateTimeoutToken()).ConfigureAwait(false);
     }
 
     static async Task Install(CancellationToken cancellationToken)

--- a/src/Tests/TemplateTests.cs
+++ b/src/Tests/TemplateTests.cs
@@ -11,7 +11,7 @@ using Particular.Approvals;
 [TestFixture]
 public class TemplateTests : IDisposable
 {
-    [SetUp]
+    [OneTimeSetUp]
     public async Task Setup()
     {
         await Uninstall(CreateTimeoutToken()).ConfigureAwait(false);


### PR DESCRIPTION
@bording this gets rid of the sync-over-async nastiness we introduced in https://github.com/Particular/dotnetTemplates/pull/291