### PR TITLE
Replace deprecated script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,6 @@
 After building the project, the templates can be installed using the following:
 
 ```
-dotnet new -u ParticularTemplates
-dotnet new -i <path to project>\nugets\ParticularTemplates.<version>.nupkg
+dotnet new uninstall ParticularTemplates
+dotnet new install <path to project>\nugets\ParticularTemplates.<version>.nupkg
 ```


### PR DESCRIPTION
Starting with the .NET 7 SDK, the dotnet new syntax has changed, using the existing syntax was giving a warning message:

Warning: use of 'dotnet new --uninstall' is deprecated. Use 'dotnet new uninstall' instead.
Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.

This PR replaced them with the latest recommended syntax